### PR TITLE
Fix translation types path

### DIFF
--- a/src/i18n/types/i18n.d.ts
+++ b/src/i18n/types/i18n.d.ts
@@ -3,7 +3,10 @@
  * Propósito: define el tipo recursivo para claves de traducción basadas en el JSON original.
  */
 
-import type en from './en.json';
+// Importamos el archivo JSON de traducciones para inferir las claves válidas.
+// La ruta original era incorrecta, lo que hacía fallar el import en tiempo de
+// compilación de tipos.
+import type en from '../locales/en.json';
 
 type RecursiveKeyOf<TObj extends object> = {
 	[TKey in keyof TObj & string]: TObj[TKey] extends object


### PR DESCRIPTION
## Summary
- correct the import path in `src/i18n/types/i18n.d.ts` so that type imports reference the actual locale file

## Testing
- `npm run type-check` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68631ea78a80832ab985090f4e1b25cd