### PR TITLE
Fix notifications button using correct drawer

### DIFF
--- a/src/components/layout/header/buttons/NotificationsCenterButton.tsx
+++ b/src/components/layout/header/buttons/NotificationsCenterButton.tsx
@@ -8,7 +8,7 @@ import ChatOutlinedIcon from '@mui/icons-material/ChatOutlined';
 
 import { useTypedTranslation } from '../../../../i18n/useTypedTranslation';
 import { appHeaderStyles } from '../../../../styles/layout/app-header.styles';
-import { LocalStorageDrawer } from '../drawers/LocalStorageDrawer';
+import { NotificationsDrawer } from '../drawers/NotificationsDrawer';
 import { useDrawerToggle } from '../../../../hooks/useDrawerToggle';
 
 /**
@@ -30,7 +30,7 @@ export const NotificationsCenterButton = () => {
 				</IconButton>
 			</Tooltip>
 
-			<LocalStorageDrawer open={open} onClose={handleClose} />
-		</>
-	);
+                        <NotificationsDrawer open={open} onClose={handleClose} />
+                </>
+        );
 };


### PR DESCRIPTION
## Summary
- fix incorrect drawer in `NotificationsCenterButton`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check` *(fails: Cannot find module '@mui/material')*

------
https://chatgpt.com/codex/tasks/task_e_686569eb34f8832a9468954c635b7ff1