### PR TITLE
Fix missing React import in AppHeaderSearch

### DIFF
--- a/src/components/layout/header/AppHeaderSearch.tsx
+++ b/src/components/layout/header/AppHeaderSearch.tsx
@@ -6,6 +6,7 @@
 import { Paper, IconButton, InputBase } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import { useTheme } from '@mui/material/styles';
+import type { FormEvent } from 'react';
 
 import { useTypedTranslation } from '../../../i18n/useTypedTranslation';
 import { appHeaderSearchStyles } from '../../../styles/layout/app-header-search.styles';
@@ -17,9 +18,9 @@ export const AppHeaderSearch = () => {
 	const theme = useTheme();
 	const { translateText } = useTypedTranslation();
 
-	const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-		event.preventDefault();
-	};
+       const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+               event.preventDefault();
+       };
 
 	return (
 		<Paper


### PR DESCRIPTION
## Summary
- fix type error in `AppHeaderSearch` by importing `FormEvent`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check` *(fails: Cannot find module '@mui/material')*

------
https://chatgpt.com/codex/tasks/task_e_686572fee7a0832ab8c7f41df68eee07