### PR TITLE
Fix import path in i18n type file

### DIFF
--- a/src/components/layout/header/AppHeaderSearch.tsx
+++ b/src/components/layout/header/AppHeaderSearch.tsx
@@ -18,9 +18,9 @@ export const AppHeaderSearch = () => {
 	const theme = useTheme();
 	const { translateText } = useTypedTranslation();
 
-       const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-               event.preventDefault();
-       };
+	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+	};
 
 	return (
 		<Paper

--- a/src/i18n/types/i18n.d.ts
+++ b/src/i18n/types/i18n.d.ts
@@ -4,7 +4,8 @@
  * y los idiomas disponibles en la aplicación.
  */
 
-import type en from './en.json';
+// Importa las traducciones base para extraer las claves disponibles
+import type en from '../locales/en.json';
 
 type RecursiveKeyOf<TObj extends object> = {
 	[TKey in keyof TObj & string]: TObj[TKey] extends object


### PR DESCRIPTION
## Summary
- correct path for the base English translations in i18n.d.ts
- run prettier on AppHeaderSearch

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run type-check` *(fails: cannot find module '@mui/material' and others)*
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_686574f4b400832aaf10355d5b77aa3f